### PR TITLE
fix(compare): revert player comparison command parameters

### DIFF
--- a/src/AdvancedBot.Core/Commands/Modules/GLModule.cs
+++ b/src/AdvancedBot.Core/Commands/Modules/GLModule.cs
@@ -174,26 +174,26 @@ public class GLModule : TopModule
     }
 
     [SlashCommand("compare", "Compare two players on base statistics", false, RunMode.Async)]
-    public async Task CompareUsersAsync(string firstPlayer, string secondPlayer)
+    public async Task CompareUsersAsync(string input1, string input2)
     {
-        if (firstPlayer.Equals(secondPlayer, StringComparison.CurrentCultureIgnoreCase))
+        if (input1.Equals(input2, StringComparison.CurrentCultureIgnoreCase))
         {
             await ModifyOriginalResponseAsync(msg => msg.Content = $"You must compare two differents players!");
             return;
         }
 
-        var baseUser = await GetUserByInput(firstPlayer);
-        var secondUser = await GetUserByInput(secondPlayer);
+        var baseUser = await GetUserByInput(input1);
+        var secondUser = await GetUserByInput(input2);
 
         if (baseUser == null)
         {
-            await ModifyOriginalResponseAsync(msg => msg.Content = $"<:shrugR:945740284308893696> Could not find any player named **{firstPlayer}**");
+            await ModifyOriginalResponseAsync(msg => msg.Content = $"<:shrugR:945740284308893696> Could not find any player named **{input1}**");
             return;
         }
 
         if (secondUser == null)
         {
-            await ModifyOriginalResponseAsync(msg => msg.Content = $"<:shrugR:945740284308893696> Could not find any player named **{secondPlayer}**");
+            await ModifyOriginalResponseAsync(msg => msg.Content = $"<:shrugR:945740284308893696> Could not find any player named **{input2}**");
             return;
         }
 


### PR DESCRIPTION
### Description

This PR just reverts the parameters name of the `compare` command to their original value.
Since the latest update, the parameters were changed but they were never reflected on discord, so it was still expecting the previous one.

I believe using `addmoduletoguild` w/ `GLModule` would've fixed it, although I'm not sure cause this module doesn't require to be added manually so it should've updated itself since then.

Anyway, this is a straightforward fix, not sure if the command is used much but atleast it'll work.
