### PR TITLE
feat: add avatar deletion command

### DIFF
--- a/src/AdvancedBot.Core/AdvancedBot.Core.csproj
+++ b/src/AdvancedBot.Core/AdvancedBot.Core.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="3.16.0" />
-    <PackageReference Include="GL.Net" Version="0.4.13" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="GL.Net" Version="0.4.14" />
     <PackageReference Include="LiteDB" Version="5.0.21" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />

--- a/src/AdvancedBot.Core/Commands/Modules/ModerationModule.cs
+++ b/src/AdvancedBot.Core/Commands/Modules/ModerationModule.cs
@@ -646,4 +646,11 @@ public class ModerationModule : TopModule
         await SendPaginatedMessageAsync(null, displayTexts, embed);
 
     }
+
+    [SlashCommand("deleteAvatar", "Deletes the targeted user's avatar")]
+    public async Task DeleteAvatarAsync(uint userId)
+    {
+        var result = await ModService.DeleteAvatarAsync(Context.User.Id, userId);
+        await SendResponseMessage(result.Message, false);
+    }
 }

--- a/src/AdvancedBot.Core/Commands/Modules/ModerationModule.cs
+++ b/src/AdvancedBot.Core/Commands/Modules/ModerationModule.cs
@@ -647,7 +647,7 @@ public class ModerationModule : TopModule
 
     }
 
-    [SlashCommand("deleteAvatar", "Deletes the targeted user's avatar")]
+    [SlashCommand("deleteavatar", "Deletes the targeted user's avatar")]
     public async Task DeleteAvatarAsync(uint userId)
     {
         var result = await ModService.DeleteAvatarAsync(Context.User.Id, userId);

--- a/src/AdvancedBot.Core/Entities/Enums/LogAction.cs
+++ b/src/AdvancedBot.Core/Entities/Enums/LogAction.cs
@@ -32,4 +32,5 @@ public enum LogAction
     GetAccounts = 27,
     GetChipsSpent = 28,
     Compensate = 29,
+    AvatarDeleted = 30,
 }

--- a/src/AdvancedBot.Core/Services/LogService.cs
+++ b/src/AdvancedBot.Core/Services/LogService.cs
@@ -148,6 +148,7 @@ public class LogService
             case LogAction.AddEmulate:
             case LogAction.RemoveEmulate:
             case LogAction.GetAccounts:
+            case LogAction.AvatarDeleted:
             default:
                 break;
         }

--- a/src/AdvancedBot.Core/Services/ModerationService.cs
+++ b/src/AdvancedBot.Core/Services/ModerationService.cs
@@ -277,7 +277,7 @@ public class ModerationService
 
         if (!await _gl.Phoenix.DeleteAvatarAsync(userId))
         {
-            return new ModResult(ModResultType.BackendError, new ResponseMessage($"Failed to remove ${user.UserName}'s avatar."));
+            return new ModResult(ModResultType.BackendError, new ResponseMessage($"Failed to remove {user.UserName}'s avatar."));
         }
 
         await _logs.LogGameActionAsync(LogAction.AvatarDeleted, discordId, userId);


### PR DESCRIPTION
### Description

This PRs add a `/deleteavatar` command that calls the recently added avatar deletion endpoint on Phoenix API.
I haven't tested the command myself as the bot requires specific credentials which I do not have, but this is a straightforward addition so it is fair to assume it'd work out of the box.
