### PR TITLE
fix: remove nullable annotation and fix reversed null check

### DIFF
--- a/src/AdvancedBot.Core/Services/LogService.cs
+++ b/src/AdvancedBot.Core/Services/LogService.cs
@@ -57,7 +57,7 @@ public class LogService
 
         if (victimId != 0)
         {
-            if (victimName == null)
+            if (victimName is not null)
             {
                 embed.AddField("Target", $"{victimName} (`{victimId}`)", true);
             }

--- a/src/AdvancedBot.Core/Services/LogService.cs
+++ b/src/AdvancedBot.Core/Services/LogService.cs
@@ -45,7 +45,7 @@ public class LogService
         await channel.SendMessageAsync(embed: GetEmbedForLog(log, user?.Name, victimGameId));
     }
 
-    public static Embed GetEmbedForLog(Log log, string? victimName, uint victimId)
+    public static Embed GetEmbedForLog(Log log, string victimName, uint victimId)
     {
         var embed = new EmbedBuilder()
             .WithTitle($"Overview | {log.Type.Humanize()}")


### PR DESCRIPTION
### Description

Removes the nullabe annotation on `GetEmbedForLog` victimName parameter as nullable types reference are not enabled in the project.

We could enable them but it would require more changes in other part of the codebase, which isnt worth the effort since the bot will be rewritten anyway.

Also fix a reserved null check in that same method, where the victimName was being used when it was checked as null.